### PR TITLE
Se agrega la funcion para que se copie los archivos .ts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
         specifier: ^0.3.20
         version: 0.3.21(mongodb@6.14.2(socks@2.8.4))(mysql2@3.13.0)(pg@8.14.0)(reflect-metadata@0.1.14)(sqlite3@5.1.7)(ts-node@10.9.2(@types/node@20.17.24)(typescript@5.8.2))
       typescript:
-        specifier: ^5.2.2
+        specifier: ^5.3.3
         version: 5.8.2
     devDependencies:
       '@types/cli-progress':

--- a/src/scripts/copy-templates.ts
+++ b/src/scripts/copy-templates.ts
@@ -12,9 +12,10 @@ async function copyTemplates() {
     // Copiar todos los archivos y directorios
     await fs.copy(srcDir, distDir, {
       filter: (src) => {
-        // Incluir solo archivos .template y directorios
-        return fs.statSync(src).isDirectory() || src.endsWith('.template');
-      }
+        const include = fs.statSync(src).isDirectory() || /\.(template|ts|js)$/.test(src);
+        console.log(`📂 Procesando: ${src} - Incluido: ${include}`);
+        return include;
+      },
     });
 
     console.log('✅ Templates copiados correctamente a dist/templates');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,9 @@
     }
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "src/**/*.ts",
+    "src/templates/**/*.ts",
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Se agrega la funcion para que se copie los archivos .ts, pero aun no se logra solucionar la novedad de la eliminacion automatica del archivo  .js en el directorio dist al terminar de ejecutar el comando npm run build 